### PR TITLE
Refactor: replace polling-based election timeout with asyncio.Event

### DIFF
--- a/aioraft/raft.py
+++ b/aioraft/raft.py
@@ -143,9 +143,9 @@ class Raft(aobject, AbstractRaftProtocol):
         await self._initialize_volatile_state()
 
         self.__commit_event = asyncio.Event()
+        self.__heartbeat_event = asyncio.Event()
 
         await self.__change_state(RaftState.FOLLOWER)
-        await self.__reset_timeout()
         await self._reset_election_timeout()
 
     async def main(self) -> None:
@@ -154,7 +154,6 @@ class Raft(aobject, AbstractRaftProtocol):
             while True:
                 match self.__state:
                     case RaftState.FOLLOWER:
-                        await self.__reset_timeout()
                         await self._wait_for_election_timeout()
                     case RaftState.CANDIDATE:
                         while self.__state is RaftState.CANDIDATE:
@@ -225,13 +224,23 @@ class Raft(aobject, AbstractRaftProtocol):
         self.__election_timeout: float = randrangef(0.15, 0.3)
 
     async def __reset_timeout(self) -> None:
-        self.__elapsed_time: float = 0.0
+        self.__heartbeat_event.set()
 
-    async def _wait_for_election_timeout(self, interval: float = 1.0 / 30) -> None:
-        while self.__elapsed_time < self.__election_timeout:
-            await asyncio.sleep(interval)
-            self.__elapsed_time += interval
-        await self.__change_state(RaftState.CANDIDATE)
+    async def _wait_for_election_timeout(self) -> None:
+        """Wait for election timeout. Returns when timeout elapses without heartbeat."""
+        while True:
+            self.__heartbeat_event.clear()
+            try:
+                await asyncio.wait_for(
+                    self.__heartbeat_event.wait(),
+                    timeout=self.__election_timeout,
+                )
+                # Heartbeat received — reset and wait again
+                continue
+            except asyncio.TimeoutError:
+                # No heartbeat within election timeout — become candidate
+                await self.__change_state(RaftState.CANDIDATE)
+                return
 
     async def __synchronize_term(self, term: int) -> None:
         if term > self.current_term:
@@ -904,8 +913,8 @@ class Raft(aobject, AbstractRaftProtocol):
         return self.__state
 
     @property
-    def _elapsed_time(self) -> float:
-        return self.__elapsed_time
+    def _heartbeat_event(self) -> asyncio.Event:
+        return self.__heartbeat_event
 
     @property
     def membership(self) -> int:

--- a/tests/test_raft.py
+++ b/tests/test_raft.py
@@ -138,8 +138,8 @@ async def test_stale_append_entries_does_not_reset_election_timer():
     # Set the node's current term to 5
     raft._Raft__current_term.set(5)
 
-    # Simulate some elapsed time (as if election timer is counting down)
-    raft._Raft__elapsed_time = 0.1
+    # Clear the heartbeat event so we can observe whether it gets set
+    raft._Raft__heartbeat_event.clear()
 
     # Send an AppendEntries with a stale term (term=2 < currentTerm=5)
     current_term, success = await raft.on_append_entries(
@@ -155,17 +155,17 @@ async def test_stale_append_entries_does_not_reset_election_timer():
     assert success is False
     assert current_term == 5
 
-    # The election timer should NOT have been reset (elapsed_time stays 0.1)
-    assert raft._elapsed_time == pytest.approx(0.1), (
-        "Election timer was reset by a stale AppendEntries RPC; "
-        "only valid RPCs should reset the timer"
+    # The heartbeat event should NOT have been set by a stale RPC
+    assert not raft._heartbeat_event.is_set(), (
+        "Heartbeat event was set by a stale AppendEntries RPC; "
+        "only valid RPCs should signal the heartbeat event"
     )
 
 
 @pytest.mark.asyncio
 async def test_valid_append_entries_resets_election_timer():
     """Verify that a valid AppendEntries RPC (with current term) does
-    reset the election timer."""
+    reset the election timer by setting the heartbeat event."""
     mock_server = MagicMock()
     mock_server.bind = MagicMock()
     mock_client = AsyncMock()
@@ -180,8 +180,8 @@ async def test_valid_append_entries_resets_election_timer():
     # Set the node's current term to 5
     raft._Raft__current_term.set(5)
 
-    # Simulate some elapsed time
-    raft._Raft__elapsed_time = 0.1
+    # Clear the heartbeat event so we can observe whether it gets set
+    raft._Raft__heartbeat_event.clear()
 
     # Send an AppendEntries with a valid term (term=5 == currentTerm)
     current_term, success = await raft.on_append_entries(
@@ -195,10 +195,10 @@ async def test_valid_append_entries_resets_election_timer():
 
     assert success is True
 
-    # The election timer should have been reset (elapsed_time back to 0.0)
-    assert raft._elapsed_time == pytest.approx(
-        0.0
-    ), "Election timer was not reset by a valid AppendEntries RPC"
+    # The heartbeat event should have been set by a valid RPC
+    assert (
+        raft._heartbeat_event.is_set()
+    ), "Heartbeat event was not set by a valid AppendEntries RPC"
 
 
 class TestStateMachine:
@@ -2022,7 +2022,9 @@ class TestInstallSnapshot:
         )
 
         raft._Raft__current_term.set(1)
-        raft._Raft__elapsed_time = 0.2
+
+        # Clear the heartbeat event so we can observe whether it gets set
+        raft._Raft__heartbeat_event.clear()
 
         await raft.on_install_snapshot(
             term=2,
@@ -2032,7 +2034,8 @@ class TestInstallSnapshot:
             data=b"{}",
         )
 
-        assert raft._elapsed_time == pytest.approx(0.0)
+        # The heartbeat event should have been set by a valid InstallSnapshot
+        assert raft._heartbeat_event.is_set()
 
 
 class TestSnapshotStorage:


### PR DESCRIPTION
## Summary

- Replace the ~33Hz polling loop in `_wait_for_election_timeout` with `asyncio.Event` + `asyncio.wait_for`, eliminating unnecessary CPU wakeups and providing instant heartbeat-driven timer resets
- Remove `__elapsed_time` field entirely; `__reset_timeout` now sets a `__heartbeat_event` that immediately unblocks the waiting coroutine
- Update all tests that referenced `_elapsed_time` to verify `_heartbeat_event` state instead

Refs: lablup/aioraft-ng#11

## Test plan

- [x] All 119 unit tests pass (`pytest tests/test_raft.py`)
- [x] `mypy aioraft/` passes with no issues
- [x] `flake8 aioraft/` passes with no issues
- [x] `black` and `isort` formatting applied
- [ ] Integration test (`test_raft_leader_election`) should be verified in a full cluster environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)